### PR TITLE
Add twitter handling for 3.10

### DIFF
--- a/cli/jgerman-twitter-bot-310.php
+++ b/cli/jgerman-twitter-bot-310.php
@@ -31,15 +31,15 @@ require dirname(__DIR__) . '/includes/twitter-base.php';
 
 $logHelper->writeLogMessage('Start JGerman Twitter Bot');
 
-$latestGithubRelease = $githubApiHelper->getLatestGithubRelease();
-$logHelper->writeLogMessage('Latest JGerman GitHub Release: ' . $latestGithubRelease->tag_name);
+$latestGithubRelease = $githubApiHelper->getLatestGithubReleaseByBranch('3.10');
+$logHelper->writeLogMessage('Latest JGerman 3.10 GitHub Release: ' . $latestGithubRelease->tag_name);
 
 // Detect the branch name so we check against the correct target branch history file
 $branchName = explode('.', $latestGithubRelease->tag_name);
 $coreReleaseBranchName = $branchName[0] . '.' . $branchName[1];
 
 $latestPublishedRelease = (string) $githubApiHelper->getLatestPublishedRelease($coreReleaseBranchName);
-$logHelper->writeLogMessage('Latest processed Release: ' . $latestPublishedRelease);
+$logHelper->writeLogMessage('Latest processed 3.10 Release: ' . $latestPublishedRelease);
 
 /**
  * GitHub Variables

--- a/src/GithubApiHelper.php
+++ b/src/GithubApiHelper.php
@@ -333,6 +333,49 @@ class GithubApiHelper
 	}
 
 	/**
+	 * Returns the latest release information by branch
+	 *
+	 * @param   string  $targetBranch  The branch target of the source repo
+	 *
+	 * @return  string  The label
+	 *
+	 * @since   1.0
+	 */
+	public function getLatestGithubReleaseByBranch($branch)
+	{
+		// Get the last 5 releases
+		$last5releases = $this->github->repositories->releases->getList($this->getOption('translation.owner'), $this->getOption('translation.repo'), $page = 0, $limit = 5);
+
+		foreach ($last5releases as $tagName => $release)
+		{
+			// Check the branch from the tag name
+			$branchName = explode('.', $tagName);
+			$coreReleaseBranchName = $branchName[0] . '.' . $branchName[1];
+
+			// The tag name does not match, continue here
+			if ($coreReleaseBranchName !== $branch)
+			{
+				continue;
+			}
+
+			// Inital value
+			if (!isset($latestTag))
+			{
+				$latestTag = $tagName;
+			}
+
+			// When we have found a newer version use it
+			if (!version_compare($tagName, $latestTag, '>'))
+			{
+				$latestTag = $tagName;
+			}
+		}
+
+		// Return the latest Tage we found
+		return $this->github->repositories->releases->getByTag($this->getOption('translation.owner'), $this->getOption('translation.repo'), $latestTag);
+	}
+
+	/**
 	 * Returns the latest run date for the item
 	 *
 	 * @param   string  $branch  The core release branch


### PR DESCRIPTION
@tecpromotion This here should add a dedicated twitter bot for the 3.10 releases. Please add a similiar cron (maybe a few minutes apart) as the `cli/jgerman-twitter-bot.php` for the `cli/jgerman-twitter-bot-310.php` once merged & deployed.

Thanks