### PR TITLE
Changed translation files taken from files changed vs language change label

### DIFF
--- a/cli/jgerman-github-bot.php
+++ b/cli/jgerman-github-bot.php
@@ -29,6 +29,11 @@ require ROOT_PATH . '/vendor/autoload.php';
 // Load the github base configuration
 require dirname(__DIR__) . '/includes/github-base.php';
 
+$tmp = $githubApiHelper->getClosedAndMergedTranslationIssuesList(new DateTime('2024-03-28'));
+
+var_dump($tmp);
+exit;
+
 $logHelper->writeLogMessage('Start JGerman GitHub Bot');
 $notifierHelper->sendLogNotification('Start JGerman GitHub Bot');
 

--- a/cli/jgerman-github-bot.php
+++ b/cli/jgerman-github-bot.php
@@ -29,11 +29,6 @@ require ROOT_PATH . '/vendor/autoload.php';
 // Load the github base configuration
 require dirname(__DIR__) . '/includes/github-base.php';
 
-$tmp = $githubApiHelper->getClosedAndMergedTranslationIssuesList(new DateTime('2024-03-28'));
-
-var_dump($tmp);
-exit;
-
 $logHelper->writeLogMessage('Start JGerman GitHub Bot');
 $notifierHelper->sendLogNotification('Start JGerman GitHub Bot');
 

--- a/src/GithubApiHelper.php
+++ b/src/GithubApiHelper.php
@@ -170,7 +170,8 @@ class GithubApiHelper
 				continue;
 			}
 
-			if ($this->github->pulls->isMerged($this->getOption('source.owner'), $this->getOption('source.repo'), $issue->number))
+			if ($this->github->pulls->isMerged($this->getOption('source.owner'), $this->getOption('source.repo'), $issue->number)
+				&& !empty($this->getChangedTranslationFilesByPR($issue->number)))
 			{
 				$closedAndMerged[] = $issue;
 			}
@@ -194,8 +195,10 @@ class GithubApiHelper
 		$state  = 'closed';
 		$labels = urlencode($this->getOption('source.watchlabel'));
 
+		$labels = NULL;
+
 		return $this->github->issues->getListByRepository(
-			$this->getOption('source.owner'), $this->getOption('source.repo'), NULL, $state, NULL, NULL, $labels, NULL, NULL, $since
+			$this->getOption('source.owner'), $this->getOption('source.repo'), NULL, $state, NULL, NULL, $labels, NULL, NULL, $since, 0, 500
 		);
 	}
 


### PR DESCRIPTION
@tecpromotion @wojsmol this is the full implementation of #13 

I'm just not sure whether we should fully get rid of the "watchlabel" feature and with that solution increase the api calls? What do you think? Should we allow both?

The reason is that today we only select merged PRs with the label but after this change we get all issues, verify that this are merged PRs and than check the changed files for each of that PRs even for PRs which are not changing language files. Opinions?